### PR TITLE
Joomla 6 compatibility: Fix deprecated CMS Filesystem class by using framework instead

### DIFF
--- a/src/src/Helper/RfAudioHelper.php
+++ b/src/src/Helper/RfAudioHelper.php
@@ -9,8 +9,8 @@
 
 namespace RichardFath\Module\RfAudio\Site\Helper;
 
-use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\Filesystem\Path;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 


### PR DESCRIPTION
This pull request (PR) fixes the PHP error `Class "Joomla\CMS\Filesystem\Path" not found` which you get on Joomla 6 when the "Behaviour - Backward Compatibility 6" plugin is disabled by using the `Joomla\Filesystem\Path` class from the Joomla Framework instead.